### PR TITLE
Removed min/max macros from def.h

### DIFF
--- a/def.h
+++ b/def.h
@@ -33,12 +33,4 @@ enum
 	 N_CMD=CMD_CLOSE+N_LOOPS
 };
 
-// Macros
-#ifndef max
-#define max(a, b) (((a) > (b)) ? a : b)
-#endif
-#ifndef min
-#define min(a, b) (((a) < (b)) ? a : b)
-#endif
-
 #endif // _DEF_H_


### PR DESCRIPTION
Those macros were unused, and they were clashing with other macros defined in `stl_algobase.h`. After this commit, the code can be built without errors. (Although with plenty of warnings.)

Full error log that is fixed by this commit: https://pastebin.com/7KmYnq5M (error at line 68, followed by 2200 additional lines of errors because the compiler and the C preprocessor got very confused after the first error)